### PR TITLE
fix: Add textarea support for snd__type class #8

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -107,7 +107,6 @@ const EVENT_CLASS_NAMES = Object.freeze(_EVENT_CLASS_NAMES);
 const TAG_EVENT_SOUND: DOMEventSound = {
 	"input:text,email,number,password,search,url,tel": {
 		events: {
-
 			"input": "type"
 		}
 	},
@@ -129,6 +128,11 @@ const TAG_EVENT_SOUND: DOMEventSound = {
 	"select": {
 		events: {
 			"change": "select"
+		}
+	},
+	"textarea": {
+		events: {
+			"input": "type"
 		}
 	},
 	"any": {


### PR DESCRIPTION
- Add textarea selector to TAG_EVENT_SOUND configuration
- Ensures snd__type class works on textarea elements as documented
- Fixes issue where textarea elements were not responding to sound events